### PR TITLE
INFRA-1680 Add filename for Erubis::Eruby for better stacktrace

### DIFF
--- a/lib/orchparty/kubernetes_application.rb
+++ b/lib/orchparty/kubernetes_application.rb
@@ -28,6 +28,7 @@ module Orchparty
         if(file_path.end_with?(".erb"))
           helm.application = OpenStruct.new(cluster_name: cluster_name, namespace: namespace)
           template = Erubis::Eruby.new(File.read(file_path))
+          template.filename = file_path
           yaml = template.result(helm.get_binding)
           file = Tempfile.new("kube-deploy.yaml")
           file.write(yaml)
@@ -232,6 +233,7 @@ module Orchparty
           output_path = File.join(output_chart_path, 'templates', "#{app_name}-#{template_name}")
 
           template = Erubis::Eruby.new(File.read(template_path))
+          template.filename = template_path
           params.app_name = app_name
           params.templates_path = templates_path
           document = template.result(CleanBinding.new.get_binding(params))
@@ -244,6 +246,7 @@ module Orchparty
         output_path = File.join(output_chart_path, 'Chart.yaml')
 
         template = Erubis::Eruby.new(File.read(template_path))
+        template.filename = template_path
         params = Hashie::Mash.new(chart_name: chart_name)
         document = template.result(CleanBinding.new.get_binding(params))
         File.write(output_path, document)


### PR DESCRIPTION
Output is now:
```
Can't load plugin: metoda_chat_client_ruby, 1.0.0; run 'minfra plugin setup'
error: My error ABC 123
Traceback (most recent call last):
	29: from /minfra/minfra-cli/vendor/bundle/ruby/2.7.0/bin/orchparty:23:in `<main>'
	28: from /minfra/minfra-cli/vendor/bundle/ruby/2.7.0/bin/orchparty:23:in `load'
	27: from /home/michael/work/metoda-infra/apps/orchparty/exe/orchparty:2:in `<top (required)>'
	26: from /home/michael/work/metoda-infra/apps/orchparty/exe/orchparty:2:in `require'
	25: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/cli.rb:69:in `<top (required)>'
	24: from /minfra/minfra-cli/vendor/bundle/ruby/2.7.0/gems/gli-2.16.1/lib/gli/app_support.rb:83:in `run'
	23: from /minfra/minfra-cli/vendor/bundle/ruby/2.7.0/gems/gli-2.16.1/lib/gli/app_support.rb:309:in `call_command'
	22: from /minfra/minfra-cli/vendor/bundle/ruby/2.7.0/gems/gli-2.16.1/lib/gli/app_support.rb:296:in `block in call_command'
	21: from /minfra/minfra-cli/vendor/bundle/ruby/2.7.0/gems/gli-2.16.1/lib/gli/command_support.rb:131:in `execute'
	20: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/cli.rb:22:in `block (2 levels) in <class:OrchPartyApp>'
	19: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty.rb:51:in `print'
	18: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:320:in `print'
	17: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:340:in `each_service'
	16: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:340:in `each'
	15: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:343:in `block in each_service'
	14: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:321:in `block in print'
	13: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:262:in `print_upgrade'
	12: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:256:in `print_install'
	11: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:192:in `build_chart'
	10: from /usr/local/lib/ruby/2.7.0/tmpdir.rb:89:in `mktmpdir'
	 9: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:193:in `block in build_chart'
	 8: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:212:in `run'
	 7: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:212:in `each'
	 6: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:214:in `block in run'
	 5: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:231:in `generate_documents_from_erbs'
	 4: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:231:in `each'
	 3: from /home/michael/work/metoda-infra/apps/orchparty/lib/orchparty/kubernetes_application.rb:239:in `block in generate_documents_from_erbs'
	 2: from /minfra/minfra-cli/vendor/bundle/ruby/2.7.0/gems/erubis-2.7.0/lib/erubis/evaluator.rb:65:in `result'
	 1: from /minfra/minfra-cli/vendor/bundle/ruby/2.7.0/gems/erubis-2.7.0/lib/erubis/evaluator.rb:65:in `eval'
/home/michael/work/metoda-infra/chart-templates/worker/deployment.yaml.erb:8:in `block in get_binding': My error ABC 123 (RuntimeError)
```